### PR TITLE
Add implementation for span instance decoration 

### DIFF
--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -46,7 +46,8 @@ module ActsAsSpan
                :expired?,
                :expired_on?,
                :past?,
-               :past_on?, to: :span
+               :past_on?,
+               :span_to_s, to: :span
 
       delegate :acts_as_span_definitions, to: :class
 

--- a/lib/acts_as_span/span_instance.rb
+++ b/lib/acts_as_span/span_instance.rb
@@ -1,3 +1,4 @@
+require 'acts_as_span/span_instance/decorator'
 require 'acts_as_span/span_instance/validations'
 require 'acts_as_span/span_instance/status'
 
@@ -5,6 +6,7 @@ require 'active_support/core_ext/module/delegation'
 
 module ActsAsSpan
   class SpanInstance
+    include ActsAsSpan::SpanInstance::Decorator
     include ActsAsSpan::SpanInstance::Validations
     include ActsAsSpan::SpanInstance::Status
 

--- a/lib/acts_as_span/span_instance/decorator.rb
+++ b/lib/acts_as_span/span_instance/decorator.rb
@@ -1,0 +1,15 @@
+module ActsAsSpan
+  class SpanInstance
+    module Decorator
+      extend ActiveSupport::Concern
+
+      included do
+        def span_to_s
+          [start_date, end_date].reject(&:blank?)
+                                .map { |x| x.strftime("%m/%d/%Y") }
+                                .join(" - ")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/delegation_spec.rb
+++ b/spec/lib/delegation_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe "Span" do
   end
 
   context "InstanceMethods" do
+    it "should delegate span_to_s" do
+      expect(span_instance).to receive(:span_to_s).and_return(true)
+
+      span_model.span_to_s
+    end
+
     it "should delegate span_status" do
       expect(span_instance).to receive(:span_status).and_return(true)
 


### PR DESCRIPTION
It's often the case that you'll want a "pretty" version of a span when rendering temporally bound resources in the UI. In general, this has led to a lot of copy-pasta across decorators/views/models/etc.

This PR is a first pass at DRY-ing this process up a bit, via: 

```ruby
irb> span_model = SpanModel.new(start_date: Date.current, end_date: Date.current + 1)
=>  #<SpanModel start_date: Wed, 12 Sep 2018, end_date: Thu, 13 Sep 2018> 

irb> span_model.span_to_s
=> "09/12/2018 - 09/13/2018" 
```