### PR TITLE
Raise when passing unsupported options to `.act_as_span`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.8
-  - 2.3.5
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.1
+before_script: gem install bundler
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.1
-before_script: gem install bundler
+before_install: gem install bundler
 notifications:
   email: false

--- a/acts_as_span.gemspec
+++ b/acts_as_span.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.15"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
   s.add_development_dependency "has_siblings", "~> 0.2.7"
   s.add_development_dependency "temping"
   s.add_development_dependency "pry-byebug"

--- a/acts_as_span.gemspec
+++ b/acts_as_span.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "bundler", "~> 1.15"
+  s.add_development_dependency "bundler", "~> 2.0.1"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "sqlite3", "~> 1.3.6"

--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -41,7 +41,7 @@ module ActsAsSpan
       unless unsupported_options.empty?
         raise ArgumentError,
           'Unsupported option(s): ' \
-          "#{unsupported_options.map { |o| "'" << o.to_s << "'" }.join(', ')}"
+          "#{unsupported_options.map { |o| "'#{o}'" }.join(', ')}"
       end
 
       acts_as_span_definitions[options.name] = options

--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -34,6 +34,7 @@ module ActsAsSpan
       self.send(:extend, ActsAsSpan::ExtendedClassMethods)
       self.send(:include, ActsAsSpan::IncludedInstanceMethods)
 
+      # TODO: There's some refactoring that could be done here using keyword args (or the more standard old hash arg pattern)
       options = OpenStruct.new(args.last.is_a?(Hash) ? ActsAsSpan.options.merge(args.pop) : ActsAsSpan.options)
 
       unsupported_options =

--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -13,6 +13,8 @@ require 'active_record'
 module ActsAsSpan
   extend ActiveSupport::Concern
 
+  OPTIONS = %i[start_field end_field name].freeze
+
   class << self
     def options
       @options ||= {
@@ -33,6 +35,14 @@ module ActsAsSpan
       self.send(:include, ActsAsSpan::IncludedInstanceMethods)
 
       options = OpenStruct.new(args.last.is_a?(Hash) ? ActsAsSpan.options.merge(args.pop) : ActsAsSpan.options)
+
+      unsupported_options =
+        options.to_h.keys.reject { |opt| OPTIONS.include? opt }
+      unless unsupported_options.empty?
+        raise ArgumentError,
+          'Unsupported option(s): ' \
+          "#{unsupported_options.map { |o| "'" << o.to_s << "'" }.join(', ')}"
+      end
 
       acts_as_span_definitions[options.name] = options
 

--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -41,8 +41,8 @@ module ActsAsSpan
         options.to_h.keys.reject { |opt| OPTIONS.include? opt }
       unless unsupported_options.empty?
         raise ArgumentError,
-          'Unsupported option(s): ' \
-          "#{unsupported_options.map { |o| "'#{o}'" }.join(', ')}"
+          'Unsupported option(s): ' <<
+          unsupported_options.map { |o| "'#{o}'" }.join(', ')
       end
 
       acts_as_span_definitions[options.name] = options

--- a/spec/lib/acts_as_span_spec.rb
+++ b/spec/lib/acts_as_span_spec.rb
@@ -1,6 +1,27 @@
 require 'spec_helper'
 
 RSpec.describe "acts_as_span" do
+  it 'raises an ArgumentError when unsupported arguments are passed' do
+    expect do
+      SpannableModel.acts_as_span(
+        start_field: :starting_date,
+        end_field: :ending_date,
+        span_overlap_scope: [:unique_by_date_range]
+      )
+    end.to raise_error(
+      ArgumentError, "Unsupported option(s): 'span_overlap_scope'"
+    )
+  end
+
+  it "doesn't raise an ArgumentError when valid arguments are passed" do
+    expect do
+      SpannableModel.acts_as_span(
+        start_field: :starting_date,
+        end_field: :ending_date
+      )
+    end.not_to raise_error
+  end
+
   context "ClassMethods" do
     it "should have 1 acts_as_span_definition" do
       expect(SpanModel.acts_as_span_definitions.size).to eq(1)

--- a/spec/spec_models.rb
+++ b/spec/spec_models.rb
@@ -4,6 +4,15 @@ require 'has_siblings'
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV["DEBUG"]
 
+Temping.create :spannable_model do
+  with_columns do |t|
+    t.date :starting_date
+    t.date :ending_date
+
+    t.integer :unique_by_date_range
+  end
+end
+
 Temping.create :span_model do
   with_columns do |t|
     t.date :start_date


### PR DESCRIPTION
The most recent release of this gem removed previously valid arguments to the `.acts_as_span` method. However, you can continue to call `.acts_as_span` with those now useless arguments and it will just swallow them up silently, giving no indicators that they aren't doing anything anymore.

This ensures that users don't rely on old arguments that don't work anymore to get the functionality that they previously relied on.

I'm not sure I really understood the point of using an `*args` splat but expecting it to at most return a single hash, which then immediately gets converted into an OpenStruct, and figured there's some refactoring that could be done there using keyword args (or the more standard old hash arg pattern) that would make it all much simpler, but I wasn't sure that it was worth the effort.