### PR TITLE
update `ActsAsSpan` default options hash syntax

### DIFF
--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -18,9 +18,9 @@ module ActsAsSpan
   class << self
     def options
       @options ||= {
-        :start_field => :start_date,
-        :end_field => :end_date,
-        :name => :default
+        start_field: :start_date,
+        end_field: :end_date,
+        name: :default
       }
     end
 


### PR DESCRIPTION
out with the old, in with the — fairly old, but relatively — new!