### PR TITLE
Revert "Adds support for changed? on start/end date fields"

### DIFF
--- a/lib/acts_as_span/span_instance.rb
+++ b/lib/acts_as_span/span_instance.rb
@@ -33,13 +33,5 @@ module ActsAsSpan
     def end_date
       span_model[end_field]
     end
-
-    def start_date_changed?
-      span_model.send("#{start_field}_changed?")
-    end
-
-    def end_date_changed?
-      span_model.send("#{end_field}_changed?")
-    end
   end
 end

--- a/spec/lib/span_instance_spec.rb
+++ b/spec/lib/span_instance_spec.rb
@@ -12,17 +12,5 @@ RSpec.describe "Span" do
     it "should return the end_date" do
       expect(span.end_date).to eq(span_model.end_date)
     end
-
-    context "changed?" do
-      it 'returns true when start_date has changed' do
-        span_model.start_date = span_model.start_date + 5
-        expect(span.start_date_changed?).to eq(true)
-      end
-
-      it 'returns true when end_date has changed' do
-        span_model.end_date = span_model.end_date + 5
-        expect(span.end_date_changed?).to eq(true)
-      end
-    end
   end
 end


### PR DESCRIPTION
Reverts annkissam/acts_as_span#16 - need to use ```saved_change_to_attribute?``` instead, as the behaviour will change in Rails 6