### PR TITLE
Adds optional include_errors param

### DIFF
--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -70,12 +70,14 @@ module ActsAsSpan
   class EndDatePropagator
     attr_reader :object,
                 :errors_cache,
-                :skipped_classes
+                :skipped_classes,
+                :include_errors
 
-    def initialize(object, errors_cache: [], skipped_classes: [])
+    def initialize(object, errors_cache: [], skipped_classes: [], include_errors: true)
       @object = object
       @errors_cache = errors_cache
       @skipped_classes = skipped_classes
+      @include_errors = include_errors
     end
 
     # class-level call: enable the usage of ActsAsSpan::EndDatePropagator.call
@@ -126,7 +128,7 @@ module ActsAsSpan
     # save the child record, add errors.
     def save_with_errors(object, child, propagated_child)
       if object_has_errors?(propagated_child)
-        errors_cache << propagation_error_message(object, child)
+        errors_cache << propagation_error_message(object, child) if include_errors
       end
       child.save
     end


### PR DESCRIPTION
This is useful for several dignyfi pages where both parent and child records are on the same page. The child errors end up showing up twice - once through normal validation + once through the end date propagation. 
- [Monday ticket](https://annkissam-team.monday.com/boards/332596247/views/4194561/pulses/631438085)