### PR TITLE
Adds ability to use custom messages when using validators

### DIFF
--- a/lib/acts_as_span/no_overlap_validator.rb
+++ b/lib/acts_as_span/no_overlap_validator.rb
@@ -42,9 +42,10 @@ module ActsAsSpan
 
       return unless overlapping_records.any? && instance_scope
 
+      error_message = options[:message] || :no_overlap
       record.errors.add(
         :base,
-        :no_overlap,
+        error_message,
         model_name: record.class.model_name.human,
         model_name_plural: record.class.model_name.plural.humanize,
         start_date: record.span.start_date,

--- a/lib/acts_as_span/within_parent_date_span_validator.rb
+++ b/lib/acts_as_span/within_parent_date_span_validator.rb
@@ -3,8 +3,10 @@ module ActsAsSpan
     def validate(record)
       parents = options[:parent] || options[:parents]
 
+      error_message = options[:message] || :not_within_parent_date_span
+
       Array(parents).each do |parent|
-        record.errors.add(:base, :not_within_parent_date_span, parent: record.class.human_attribute_name(parent)) if outside_of_parent_date_span?(record, parent)
+        record.errors.add(:base, error_message, parent: record.class.human_attribute_name(parent)) if outside_of_parent_date_span?(record, parent)
       end
     end
 

--- a/spec/lib/no_overlap_validator_spec.rb
+++ b/spec/lib/no_overlap_validator_spec.rb
@@ -116,4 +116,14 @@ RSpec.describe ActsAsSpan::NoOverlapValidator do
       end
     end
   end
+
+  describe 'error messages' do
+    let(:child_class) { OneParentChildCustom }
+    let(:new_child_start_date) { sister_start_date }
+    let(:new_child_end_date) { sister_end_date }
+    it 'allows using custom error messages' do
+      expect(new_child).not_to be_valid
+      expect(new_child.errors.messages[:base]).to include('Custom error message')
+    end
+  end
 end

--- a/spec/lib/within_parent_date_span_validator_spec.rb
+++ b/spec/lib/within_parent_date_span_validator_spec.rb
@@ -112,4 +112,15 @@ RSpec.describe ActsAsSpan::WithinParentDateSpanValidator do
       end
     end
   end
+
+  describe 'error messages' do
+    let(:child_class) { OneParentChildCustom }
+    let(:new_child_start_date) { mama_start_date - 3.days }
+    let(:new_child_end_date) { mama_end_date + 5.days }
+
+    it 'allows using custom error messages' do
+      expect(new_child).not_to be_valid
+      expect(new_child.errors.messages[:base]).to include('Custom error message')
+    end
+  end
 end

--- a/spec/spec_models.rb
+++ b/spec/spec_models.rb
@@ -47,6 +47,32 @@ Temping.create :one_parent_child do
   validates_with ActsAsSpan::WithinParentDateSpanValidator, parents: [:mama]
 end
 
+Temping.create :one_parent_child_custom do
+  with_columns do |t|
+    t.belongs_to :mama
+
+    t.date :start_date
+    t.date :end_date
+
+    # every one-parent child is a favorite! ...by default
+    t.boolean :favorite, default: true
+  end
+
+  acts_as_span
+
+  def favorite?
+    favorite
+  end
+
+  belongs_to :mama
+  has_siblings through: [:mama]
+
+  validates_with ActsAsSpan::NoOverlapValidator,
+    scope: proc { siblings }, instance_scope: proc { favorite? }, message: 'Custom error message'
+  validates_with ActsAsSpan::WithinParentDateSpanValidator, parents: [:mama], message: 'Custom error message'
+end
+
+
 Temping.create :two_parent_child do
   with_columns do |t|
     t.belongs_to :mama
@@ -76,6 +102,7 @@ Temping.create :mama do
 
   has_many :one_parent_children
   has_many :two_parent_children
+  has_many :one_parent_child_customs
 end
 
 Temping.create :papa do


### PR DESCRIPTION
Dignyfi ticket [here](https://annkissam-team.monday.com/boards/332596247/pulses/631460034). 
Requirement was initially for the sibling validator, but added it to the WithinParentSpan so it's there if we ever need it. 