### PR TITLE
Expose "current" Arel of SpanKlass::Status concern

### DIFF
--- a/lib/acts_as_span/span_klass/status.rb
+++ b/lib/acts_as_span/span_klass/status.rb
@@ -12,16 +12,6 @@ module ActsAsSpan
           )
         end
 
-        def current_condition(query_date:, table:)
-          start_col = arel_table[start_field]
-          end_col = arel_table[end_field]
-
-          start_condition = start_col.lteq(query_date).or(start_col.eq(nil))
-          end_condition = end_col.eq(nil).or(end_col.gteq(query_date))
-
-          start_condition.and(end_condition)
-        end
-
         alias_method :current_on, :current
 
         def future(query_date = Date.current)
@@ -51,6 +41,19 @@ module ActsAsSpan
         end
 
         alias_method :current_or_future, :current_or_future_on
+
+        private
+
+        # returns an Arel node usable within an ActiveRecord `where` clause
+        def current_condition(query_date:, table:)
+          start_col = arel_table[start_field]
+          end_col = arel_table[end_field]
+
+          start_condition = start_col.lteq(query_date).or(start_col.eq(nil))
+          end_condition = end_col.eq(nil).or(end_col.gteq(query_date))
+
+          start_condition.and(end_condition)
+        end
       end
     end
   end

--- a/lib/acts_as_span/span_klass/status.rb
+++ b/lib/acts_as_span/span_klass/status.rb
@@ -8,11 +8,18 @@ module ActsAsSpan
       included do
         def current(query_date = Date.current)
           klass.where(
-            (arel_table[start_field].lteq(query_date).or(arel_table[start_field].eq(nil))).
-            and(
-              arel_table[end_field].eq(nil).or(arel_table[end_field].gteq(query_date))
-            )
+            current_condition(query_date: query_date, table: arel_table)
           )
+        end
+
+        def current_condition(query_date:, table:)
+          start_col = arel_table[start_field]
+          end_col = arel_table[end_field]
+
+          start_condition = start_col.lteq(query_date).or(start_col.eq(nil))
+          end_condition = end_col.eq(nil).or(end_col.gteq(query_date))
+
+          start_condition.and(end_condition)
         end
 
         alias_method :current_on, :current

--- a/spec/lib/span_klass/status_spec.rb
+++ b/spec/lib/span_klass/status_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe ActsAsSpan::SpanKlass::Status do
   let(:span_klass) { ::SpanModel }
 
-  let(:today) { Date.new(2020, 10, 31) }
+  let!(:today) { Date.current }
 
   describe '.current' do
     let!(:record) do

--- a/spec/lib/span_klass/status_spec.rb
+++ b/spec/lib/span_klass/status_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActsAsSpan::SpanKlass::Status do
+  let(:span_klass) { ::SpanModel }
+
+  let(:today) { Date.new(2020, 10, 31) }
+
+  describe '.current' do
+    let!(:record) do
+      span_klass.create(
+        start_date: today - 1.week,
+        end_date: today + 1.week,
+      )
+    end
+
+    subject { span_klass.current(query_date) }
+
+    context 'when query_date is the current date' do
+      let(:query_date) { record.start_date + 3.days }
+
+      it { is_expected.not_to be_empty }
+    end
+
+    context "when query_date is before the record's span" do
+      let(:query_date) { record.start_date - 1.week }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when query_date is after the record's span" do
+      let(:query_date) { record.end_date + 1.week }
+
+      it { is_expected.to be_empty }
+    end
+  end
+end

--- a/spec/lib/span_klass/status_spec.rb
+++ b/spec/lib/span_klass/status_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ActsAsSpan::SpanKlass::Status do
 
     subject { span_klass.current(query_date) }
 
-    context 'when query_date is the current date' do
+    context "when query_date is within the record's span" do
       let(:query_date) { record.start_date + 3.days }
 
       it { is_expected.not_to be_empty }


### PR DESCRIPTION
There are some use cases where one would like to use the "current" condition Arel node.
This refactor exposes that while keeping it fully backwards compatible.

TODO:
- [ ] ~~Add specs for the rest of the `Status` concern~~
- [ ] ~~Extract the other status scopes' Arel in a similar way~~ Out of scope, make an issue
- [x] Add documentation
- [x] Clean it up ;)
- [ ] ~~Update changelog? Is that a thing?~~ edit: no! add changelog?
- [ ] ~~Bump version - I think there were some recent changes that didn't come with a bump.~~ Actually, this should be a different PR.

Relevant PRs:
* annkissam/fms_enrollment_birch#2388
* annkissam/fms_enrollment_birch#2392