### PR TITLE
Lock Rails-adjacent gems and Bundler versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.5
-before_install: gem install bundler
+before_install: gem install bundler:2.1.4
 notifications:
   email: false

--- a/acts_as_span.gemspec
+++ b/acts_as_span.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
 
   # End Date Propagator breaks for Rails 6.1; Release a new minor version
   #   so any apps stuck in Rails 5 can lock more easily.
-  s.add_runtime_dependency('activerecord', '~> 5.2.4.4')
-  s.add_runtime_dependency('activesupport', '~> 5.2.4.4')
+  s.add_runtime_dependency('activerecord', '< 6.0', '>= 4.2.0')
+  s.add_runtime_dependency('activesupport', '<6.0', '>= 4.2.0')
 end

--- a/acts_as_span.gemspec
+++ b/acts_as_span.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "temping"
   s.add_development_dependency "pry-byebug"
 
-  s.add_runtime_dependency('activerecord', '>= 4.2.0')
-  s.add_runtime_dependency('activesupport', '>= 4.2.0')
+  # End Date Propagator breaks for Rails 6.1; Release a new minor version
+  #   so any apps stuck in Rails 5 can lock more easily.
+  s.add_runtime_dependency('activerecord', '~> 5.2.4.4')
+  s.add_runtime_dependency('activesupport', '~> 5.2.4.4')
 end


### PR DESCRIPTION
Example failing build: https://travis-ci.org/github/annkissam/acts_as_span/builds/750206208

This PR ensures that Rails is at a compatible version (4.2 <-> 5.2), but upgrading to Rails 6 breaks the way the EndDatePropagator handles error propagation. This should be fixed in early Q1, and then the gem will get a minor version bump, and note in the readme for incompatible versions.