### PR TITLE
Apply messages directly, not via keyword.

### DIFF
--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -89,9 +89,7 @@ module ActsAsSpan
       result = propagate
       # only add new errors to the object
       result.errors.each do |error, message|
-        unless object.errors[error].include? message
-          object.errors.add(error, message: message)
-        end
+        object.errors.add(error) if object.errors[error].exclude? message
       end
       object
     end
@@ -114,7 +112,7 @@ module ActsAsSpan
         errors_cache.each do |message|
           skip if object.errors.added?(:base, message)
 
-          object.errors.add(:base, message: message)
+          object.errors.add(:base, message)
         end
       end
 

--- a/lib/acts_as_span/version.rb
+++ b/lib/acts_as_span/version.rb
@@ -4,7 +4,7 @@ module ActsAsSpan
   module VERSION
     MAJOR = 1
     MINOR = 2
-    TINY  = 0
+    TINY  = 1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/spec/lib/end_date_propagator_spec.rb
+++ b/spec/lib/end_date_propagator_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ActsAsSpan::EndDatePropagator do
       end
       it "the parent shows that grandchild's errors" do
         expect(
-          end_date_propagator.call.errors.values.join
+          end_date_propagator.call.errors.full_messages.join
         ).to include(
           I18n.t(
             'not_within_parent_date_span',
@@ -114,7 +114,7 @@ RSpec.describe ActsAsSpan::EndDatePropagator do
         end
         it "the parent gains all children's errors" do
           expect(
-            end_date_propagator.call.errors.values.join
+            end_date_propagator.call.errors.full_messages.join
           ).to include(
             I18n.t(
               'not_within_parent_date_span',
@@ -135,7 +135,7 @@ RSpec.describe ActsAsSpan::EndDatePropagator do
         let(:include_errors) { false }
 
         it 'does not push any child errors' do
-          expect(end_date_propagator.call.errors.values).to be_empty
+          expect(end_date_propagator.call.errors.full_messages).to be_empty
         end
       end
     end


### PR DESCRIPTION
Rails flash messages will render a hash with `:messages` key instead of
just the message. Since that is a Rails standard, it makes more sense to
fix it in this gem instead of overriding the flash responder in every
Rails app.