### PR TITLE
Fix a syntax error in EndDatePropagator#propagate

### DIFF
--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -88,8 +88,10 @@ module ActsAsSpan
     def call
       result = propagate
       # only add new errors to the object
-      result.errors.each do |error, message|
-        object.errors.add(error) if object.errors[error].exclude? message
+      result.errors.each do |error|
+        if object.errors[error.attribute].exclude? error.message
+          object.errors.add(error.attribute, error.message)
+        end
       end
       object
     end
@@ -110,7 +112,7 @@ module ActsAsSpan
 
       if errors_cache.present?
         errors_cache.each do |message|
-          skip if object.errors.added?(:base, message)
+          next if object.errors.added?(:base, message)
 
           object.errors.add(:base, message)
         end

--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -88,15 +88,36 @@ module ActsAsSpan
     def call
       result = propagate
       # only add new errors to the object
-      result.errors.each do |error|
-        if object.errors[error.attribute].exclude? error.message
-          object.errors.add(error.attribute, error.message)
-        end
+
+      # NOTE: Rails 5 support
+      if ActiveRecord::VERSION::MAJOR > 5
+        add_errors(result.errors)
+      else
+        add_rails_5_errors(result.errors)
       end
+
       object
     end
 
     private
+
+    def add_errors(errors)
+      errors.each do |error|
+        if object.errors[error.attribute].exclude? error.message
+          object.errors.add(error.attribute, error.message)
+        end
+      end
+    end
+
+    # Treat errors like a Hash
+    # NOTE: Rails 5 support
+    def add_rails_5_errors(errors)
+      errors.each do |attribute, message|
+        if object.errors[attribute].exclude? message
+          object.errors.add(attribute, message)
+        end
+      end
+    end
 
     def propagate
       # return if there is nothing to propagate

--- a/lib/acts_as_span/version.rb
+++ b/lib/acts_as_span/version.rb
@@ -4,7 +4,7 @@ module ActsAsSpan
   module VERSION
     MAJOR = 1
     MINOR = 2
-    TINY  = 1
+    TINY  = 2
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/spec/lib/end_date_propagator_spec.rb
+++ b/spec/lib/end_date_propagator_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 RSpec.describe ActsAsSpan::EndDatePropagator do
   let(:end_date_propagator) do
     ActsAsSpan::EndDatePropagator.new(
-      base_instance, skipped_classes: skipped_classes,
-      include_errors: include_errors
+      base_instance,
+      skipped_classes: skipped_classes,
+      include_errors: include_errors,
     )
   end
 
@@ -297,6 +298,30 @@ RSpec.describe ActsAsSpan::EndDatePropagator do
       it 'does not throw an error' do
         expect(cat_instance).not_to respond_to(:end_date)
         expect{ end_date_propagator.call }.not_to raise_error
+      end
+    end
+
+    context 'when the record already has a validation that would be added' do
+      let(:end_date) { Date.current }
+
+      before do
+        base_instance.save!
+        base_instance.end_date = end_date
+        base_instance.errors.add(:base, 'Child is bad')
+
+        child_instance.manual_invalidation = true
+        child_instance.save(validate: false)
+
+        # add the error that would be added by the child's propagation
+        base_instance.errors.add(
+          :base,
+          "Base could not propagate Emancipation date to Child:\nChild is bad",
+        )
+      end
+
+      it 'does not add the duplicate error' do
+        expect { end_date_propagator.call }
+          .not_to(change(base_instance, :errors))
       end
     end
 

--- a/spec/spec_models.rb
+++ b/spec/spec_models.rb
@@ -170,9 +170,11 @@ Temping.create :child do
   validates_with ActsAsSpan::WithinParentDateSpanValidator,
     parents: [:base]
 
+  validate :not_manually_invalidated
+
   acts_as_span(
     start_field: :date_of_birth,
-    end_field: :emancipation_date
+    end_field: :emancipation_date,
   )
 
   with_columns do |t|
@@ -180,6 +182,12 @@ Temping.create :child do
     t.date :emancipation_date
     t.string :manual_invalidation
     t.belongs_to :base
+  end
+
+  def not_manually_invalidated
+    return if manual_invalidation.blank? || manual_invalidation == false
+
+    errors.add(:base, 'Child is bad')
   end
 end
 


### PR DESCRIPTION
'skip' is a python keyword that does what 'next' does in Ruby

we otter add Rails 6 to travis (paperclip did this using appraisal: https://github.com/thoughtbot/paperclip/blob/master/.travis.yml)