### PR TITLE
End Date Propagator Rails 5 support must include Rails 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Please include the Github issue or pull request number when applicable
   * `current` -> `current_condition`
   * `expired` (aka `past`) -> `expired_condition`
   * `future` -> `future_condition`
+## Fixed
+- Rails 5 support for the EndDatePropagator needed to be extended into Rails 6.0
+  #34
 
 ## 1.2.2
 ### Added

--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -89,8 +89,10 @@ module ActsAsSpan
       result = propagate
       # only add new errors to the object
 
-      # NOTE: Rails 5 support
-      if ActiveRecord::VERSION::MAJOR > 5
+      # NOTE: Rails < 6.1 support
+      # Errors are an array of Error objects in Rails 6.1 +
+      if ActiveRecord::VERSION::MAJOR > 5 ||
+         (ActiveRecord::Version::MAJOR == 6 && ActiveRecord::VERSION::MINOR > 1)
         add_errors(result.errors)
       else
         add_rails_5_errors(result.errors)

--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -91,11 +91,11 @@ module ActsAsSpan
 
       # NOTE: Rails < 6.1 support
       # Errors are an array of Error objects in Rails 6.1 +
-      if ActiveRecord::VERSION::MAJOR > 5 ||
-         (ActiveRecord::VERSION::MAJOR == 6 && ActiveRecord::VERSION::MINOR > 1)
-        add_errors(result.errors)
-      else
+      if ActiveRecord::VERSION::MAJOR <= 5 ||
+          (ActiveRecord::VERSION::MAJOR == 6 && ActiveRecord::VERSION::MINOR < 1)
         add_rails_5_errors(result.errors)
+      else
+        add_errors(result.errors)
       end
 
       object

--- a/lib/acts_as_span/end_date_propagator.rb
+++ b/lib/acts_as_span/end_date_propagator.rb
@@ -92,7 +92,7 @@ module ActsAsSpan
       # NOTE: Rails < 6.1 support
       # Errors are an array of Error objects in Rails 6.1 +
       if ActiveRecord::VERSION::MAJOR > 5 ||
-         (ActiveRecord::Version::MAJOR == 6 && ActiveRecord::VERSION::MINOR > 1)
+         (ActiveRecord::VERSION::MAJOR == 6 && ActiveRecord::VERSION::MINOR > 1)
         add_errors(result.errors)
       else
         add_rails_5_errors(result.errors)


### PR DESCRIPTION
## Checklist
- [x] Continuous integration passes, or no functional code was changed
- [x] Changelog entry added, or no entry is necessary

## Notes
I misinterpreted the deprecation warning in the initial PR that added support. In Rails <= 6.0, errors is a hash. In 6.1+, errors is an array of error objects. In 6.1 and its patches, errors can be decomposed with each like a hash, but it spews a deprecation warning.
I had assumed the deprecation came in Rails 6, but it does not.


It may be time for a new version after this dude