### PR TITLE
Add `earliest` and `latest` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please include the Github issue or pull request number when applicable
   * `expired` (aka `past`) -> `expired_condition`
   * `future` -> `future_condition`
 - `earliest` and `latest` methods, which return the earliest or latest record
-  in a collection of spanned records.
+  in a collection of spanned records #36
 ## Fixed
 - Rails 5 support for the EndDatePropagator needed to be extended into Rails 6.0
   #34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Please include the Github issue or pull request number when applicable
   * `current` -> `current_condition`
   * `expired` (aka `past`) -> `expired_condition`
   * `future` -> `future_condition`
+- `earliest` and `latest` methods, which return the earliest or latest record
+  in a collection of spanned records.
 ## Fixed
 - Rails 5 support for the EndDatePropagator needed to be extended into Rails 6.0
   #34

--- a/lib/acts_as_span.rb
+++ b/lib/acts_as_span.rb
@@ -62,6 +62,12 @@ module ActsAsSpan
         # expose all scope method names to the application for use in, for
         #   example, Ransack
         delegate(:span_scopes, to: :span)
+
+        # add methods like 'latest' to a class
+        delegate(
+          *ActsAsSpan::SpanKlass::Superlatives::METHOD_SYMBOLS,
+          to: :span,
+        )
       end
 
       validate :validate_spans

--- a/lib/acts_as_span/span_klass.rb
+++ b/lib/acts_as_span/span_klass.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'acts_as_span/span_klass/status'
+require 'acts_as_span/span_klass/superlatives'
 
 require 'active_support/core_ext/module/delegation'
 
 module ActsAsSpan
   class SpanKlass
     include ActsAsSpan::SpanKlass::Status
+    include ActsAsSpan::SpanKlass::Superlatives
 
     delegate :start_field,
              :end_field,

--- a/lib/acts_as_span/span_klass/superlatives.rb
+++ b/lib/acts_as_span/span_klass/superlatives.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_record'
+
+module ActsAsSpan
+  class SpanKlass
+    # Defines span superlatives (e.g. "latest" or "earliest") for use on
+    #   collections of records that act as span
+    module Superlatives
+      extend ActiveSupport::Concern
+
+      included do
+        def method_symbols
+          METHOD_SYMBOLS
+        end
+
+        # Retrieves the earliest record in a collection of spanned records.
+        # Note: Calls '.reorder' on the class, removing existing orders in the
+        #   collection.
+        #
+        # Options:
+        # * :by (default: :start)
+        #   A symbol from [:start, :start_date, :end, :end_date]
+        #   The end of the span to sort by. If set to `:start` or `:start_date`,
+        #     finds the record with the earliest value in the start date.
+        #     If set to `:end` or `:end_date`, finds the record with the
+        #     earliest end date.
+        # * :additional_order (default: {})
+        #   A Hash that provides additional sorting. If one of the span fields
+        #     are included in this argument, this method will _not_ overwrite
+        #     the original order for that field.
+        #   The Hash is of the form { field_name: :asc, field_name_2: :desc }
+        #
+        # Example:
+        #   collection.latest(by: :end, order: { id: :desc, name: :asc })
+        def earliest(by: :start)
+          field = field_from_option(by)
+
+          klass.order(field => :asc).first
+        end
+
+        # Retrieves the latest record in a collection of spanned records.
+        # Note: Calls '.reorder' on the class, removing existing orders in the
+        #   collection.
+        #
+        # Options:
+        # * :by (default: :start)
+        #   A symbol from [:start, :start_date, :end, :end_date]
+        #   The end of the span to sort by. If set to `:start` or `:start_date`,
+        #     finds the record with the latest value in the start date.
+        #     If set to `:end` or `:end_date`, finds the record with the
+        #     latest end date.
+        # * :additional_order (default: {})
+        #   A Hash that provides additional sorting. If one of the span fields
+        #     are included in this argument, this method will _not_ overwrite
+        #     the original order for that field.
+        #   The Hash is of the form { field_name: :asc, field_name_2: :desc }
+        #
+        # Example:
+        #   collection.latest(by: :end, order: { created_at: :asc })
+        def latest(by: :start)
+          field = field_from_option(by)
+
+          klass.order(field => :desc).first
+        end
+
+        private
+
+        # Take things like "start" or "start_date" and turn them into suitable
+        #   field symbols.
+        #
+        # Examples:
+        #   field_from_option(:start)       # => :start
+        #   field_from_option('start_date') # => :start
+        #   field_from_option(:strat)       # raises ArgumentError
+        def field_from_option(option)
+          option = option&.to_sym
+
+          if %i[start start_date].include? option
+            start_field
+          elsif %i[end end_date].include? option
+            end_field
+          else
+            raise ArgumentError, "Unknown option: #{option}"
+          end
+        end
+      end
+
+      METHOD_SYMBOLS = %i[earliest latest].freeze
+    end
+  end
+end

--- a/spec/lib/delegation_spec.rb
+++ b/spec/lib/delegation_spec.rb
@@ -1,92 +1,106 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-RSpec.describe "Span" do
-  let(:span_model) { SpanModel.new(:start_date => Date.current, :end_date => nil) }
+RSpec.describe 'Span' do
+  let(:span_model) { SpanModel.new(start_date: Date.current, end_date: nil) }
   let(:span_klass) { SpanModel.span }
   let(:span_instance) { span_model.span }
 
-  context "ClassMethods" do
-    it "should delegate current" do
+  describe 'ClassMethods' do
+    it 'delegates .earliest' do
+      expect(span_klass).to receive(:earliest).and_return(true)
+
+      SpanModel.earliest
+    end
+
+    it 'delegates .latest' do
+      expect(span_klass).to receive(:earliest).and_return(true)
+
+      SpanModel.earliest
+    end
+
+    it 'should delegate current' do
       expect(span_klass).to receive(:current).and_return(true)
 
       SpanModel.current
     end
 
-    it "should delegate current_on" do
+    it 'should delegate current_on' do
       expect(span_klass).to receive(:current_on).and_return(true)
 
       SpanModel.current_on
     end
 
-    it "should delegate future" do
+    it 'should delegate future' do
       expect(span_klass).to receive(:future).and_return(true)
 
       SpanModel.future
     end
 
-    it "should delegate future_on" do
+    it 'should delegate future_on' do
       expect(span_klass).to receive(:future_on).and_return(true)
 
       SpanModel.future_on
     end
 
-    it "should delegate expired" do
+    it 'should delegate expired' do
       expect(span_klass).to receive(:expired).and_return(true)
 
       SpanModel.expired
     end
 
-    it "should delegate expired_on" do
+    it 'should delegate expired_on' do
       expect(span_klass).to receive(:expired_on).and_return(true)
 
       SpanModel.expired_on
     end
   end
 
-  context "InstanceMethods" do
-    it "should delegate span_status" do
+  describe 'InstanceMethods' do
+    it 'should delegate span_status' do
       expect(span_instance).to receive(:span_status).and_return(true)
 
       span_model.span_status
     end
 
-    it "should delegate span_status_on" do
+    it 'should delegate span_status_on' do
       expect(span_instance).to receive(:span_status_on).and_return(true)
 
       span_model.span_status_on
     end
 
-    it "should delegate current?" do
+    it 'should delegate current?' do
       expect(span_instance).to receive(:current?).and_return(true)
 
       span_model.current?
     end
 
-    it "should delegate current_on?" do
+    it 'should delegate current_on?' do
       expect(span_instance).to receive(:current_on?).and_return(true)
 
       span_model.current_on?
     end
 
-    it "should delegate future?" do
+    it 'should delegate future?' do
       expect(span_instance).to receive(:future?).and_return(true)
 
       span_model.future?
     end
 
-    it "should delegate future_on?" do
+    it 'should delegate future_on?' do
       expect(span_instance).to receive(:future_on?).and_return(true)
 
       span_model.future_on?
     end
 
-    it "should delegate expired?" do
+    it 'should delegate expired?' do
       expect(span_instance).to receive(:expired?).and_return(true)
 
       span_model.expired?
     end
 
-    it "should delegate expired_on?" do
+    it 'should delegate expired_on?' do
       expect(span_instance).to receive(:expired_on?).and_return(true)
 
       span_model.expired_on?

--- a/spec/lib/span_klass/superlatives_spec.rb
+++ b/spec/lib/span_klass/superlatives_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActsAsSpan::SpanKlass::Superlatives do
+  let(:span_klass) { ::SpanModel }
+
+  let!(:today) { Date.current }
+
+  let!(:earlier_record) do
+    span_klass.create(
+      start_date: earlier_start_date,
+      end_date: earlier_end_date,
+    )
+  end
+  let!(:later_record) do
+    span_klass.create(
+      start_date: later_start_date,
+      end_date: later_end_date,
+    )
+  end
+
+  let(:earlier_start_date) { today - 2.weeks }
+  let(:earlier_end_date) { today + 1.week }
+
+  let(:later_start_date) { today - 1.week }
+  let(:later_end_date) { today + 2.weeks }
+
+  describe '.latest' do
+    subject(:result) { span_klass.latest(**options) }
+
+    context 'with no options' do
+      let(:options) { {} }
+
+      it 'returns the record with the latest start field' do
+        expect(result).to eq(later_record)
+      end
+    end
+
+    context 'when called on a relation' do
+      subject(:result) { span_klass.where.not(start_date: nil).latest }
+
+      it 'returns the record with the latest start field' do
+        expect(result).to eq(later_record)
+      end
+    end
+
+    describe ':by' do
+      let(:options) { { by: by } }
+
+      context 'when :start' do
+        let(:by) { :start }
+
+        it 'returns the record with the latest start field' do
+          expect(result).to eq(later_record)
+        end
+      end
+
+      context 'when :end' do
+        let(:by) { 'end_date' }
+
+        it 'returns the record with the latest end field' do
+          expect(result).to eq(later_record)
+        end
+      end
+    end
+  end
+
+  describe '.earliest' do
+    subject(:result) { span_klass.earliest(**options) }
+
+    context 'with no options' do
+      let(:options) { {} }
+
+      it 'returns the record with the earliest start field' do
+        expect(result).to eq(earlier_record)
+      end
+    end
+
+    context 'when called on a relation' do
+      subject(:result) { span_klass.where.not(start_date: nil).earliest }
+
+      it 'returns the record with the earliest start field' do
+        expect(result).to eq(earlier_record)
+      end
+    end
+
+    describe ':by' do
+      let(:options) { { by: by } }
+
+      context 'when :start' do
+        let(:by) { :start_date }
+
+        it 'returns the record with the earliest start field' do
+          expect(result).to eq(earlier_record)
+        end
+      end
+
+      context 'when :end' do
+        let(:by) { :end }
+
+        it 'returns the record with the earliest end field' do
+          expect(result).to eq(earlier_record)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Checklist
- [x] Continuous integration passes, or no functional code was changed
- [x] Changelog entry added, or no entry is necessary

## Notes

Starts to address the follow-up from #26

@oneamtu I think I will release 1.3.0 once I add the overlap methods (#37)